### PR TITLE
Add md4 support

### DIFF
--- a/lib/ntlm.js
+++ b/lib/ntlm.js
@@ -389,8 +389,9 @@ function binaryArray2bytes(array) {
 
 function create_NT_hashed_password_v1(password) {
     const buf = new Buffer(password, 'utf16le');
-    const md4 = crypto.createHash('md4');
+    const md4 = jsmd4.create();
     md4.update(buf);
+    
     return new Buffer(md4.digest());
 }
 

--- a/lib/ntlm.js
+++ b/lib/ntlm.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const jsmd4 = require('js-md4');
 
 const flags = {
     NTLM_NegotiateUnicode: 0x00000001,

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,14 +28,6 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
-    "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-      "requires": {
-        "lodash": "^4.17.10"
-      }
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -176,6 +168,11 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU="
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -206,11 +203,6 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
-    },
-    "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "mime-db": {
       "version": "1.37.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "request-simple-ntlm is a Node.js library to do HTTP NTLM authentication using request module",
   "version": "1.1.0",
   "dependencies": {
+    "js-md4": "^0.3.2",
     "request": "^2.88.0"
   },
   "author": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,13 @@
 var ntlm = require('request-simple-ntlm');
 
+var url = '';
+var username = '';
+var password = '';
+
 var options = {
-    url: "<url>",
-    username: "<username>",
-    password: "<password>",
+    url: url,
+    username: username,
+    password: password,
     request: {
         headers: {
             'Accept': 'application/json'


### PR DESCRIPTION
Fixed md4 hashing for NTLM v1 authentication since the crypto module does not support it anymore in later versions of Node.